### PR TITLE
Hide post metadata on protected pages until user authenticates

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -19,6 +19,9 @@ export async function generateMetadata({
   const { slug } = await params;
   const post = await getPostBySlug(slug);
   if (!post) return { title: 'Not Found' };
+  if (post.isPrivate) {
+    return { title: 'Protected Post' };
+  }
   return {
     title: post.title,
     description: post.description || undefined,
@@ -48,8 +51,9 @@ export default async function BlogPost({
   const post = await getPostBySlug(slug);
   if (!post) notFound();
 
-  const metadata = (
+  const header = (
     <>
+      <h1 style={{ marginBottom: '0.25rem' }}>{post.title}</h1>
       <div className="flex flex-wrap items-center gap-x-3 text-sm" style={{ color: 'var(--color-text-muted)' }}>
         <time dateTime={post.date}>{formatDate(post.date)}</time>
         {post.author && (
@@ -80,24 +84,23 @@ export default async function BlogPost({
 
   return (
     <article className="prose">
-      <header className="mb-8">
-        <p style={{ marginBottom: '0.5rem' }}>
-          <Link
-            href="/"
-            className="text-sm no-underline hover:underline"
-            style={{ color: 'var(--color-text-muted)' }}
-          >
-            &larr; Home
-          </Link>
-        </p>
-        <h1 style={{ marginBottom: '0.25rem' }}>{post.title}</h1>
-        {!post.isPrivate && metadata}
-      </header>
+      <p style={{ marginBottom: '0.5rem' }}>
+        <Link
+          href="/"
+          className="text-sm no-underline hover:underline"
+          style={{ color: 'var(--color-text-muted)' }}
+        >
+          &larr; Home
+        </Link>
+      </p>
 
       {post.isPrivate ? (
-        <PasswordGate slug={post.slug} metadata={metadata} />
+        <PasswordGate slug={post.slug}>{header}</PasswordGate>
       ) : (
-        <PostContent pageId={post.id} />
+        <>
+          <header className="mb-8">{header}</header>
+          <PostContent pageId={post.id} />
+        </>
       )}
     </article>
   );

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -48,6 +48,36 @@ export default async function BlogPost({
   const post = await getPostBySlug(slug);
   if (!post) notFound();
 
+  const metadata = (
+    <>
+      <div className="flex flex-wrap items-center gap-x-3 text-sm" style={{ color: 'var(--color-text-muted)' }}>
+        <time dateTime={post.date}>{formatDate(post.date)}</time>
+        {post.author && (
+          <>
+            <span aria-hidden="true">&middot;</span>
+            <span>{post.author}</span>
+          </>
+        )}
+      </div>
+      {post.tags.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-3">
+          {post.tags.map((tag) => (
+            <span
+              key={tag}
+              className="text-xs px-2 py-0.5 rounded-full"
+              style={{
+                backgroundColor: 'var(--color-code-bg)',
+                color: 'var(--color-text-muted)',
+              }}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </>
+  );
+
   return (
     <article className="prose">
       <header className="mb-8">
@@ -61,35 +91,11 @@ export default async function BlogPost({
           </Link>
         </p>
         <h1 style={{ marginBottom: '0.25rem' }}>{post.title}</h1>
-        <div className="flex flex-wrap items-center gap-x-3 text-sm" style={{ color: 'var(--color-text-muted)' }}>
-          <time dateTime={post.date}>{formatDate(post.date)}</time>
-          {post.author && (
-            <>
-              <span aria-hidden="true">&middot;</span>
-              <span>{post.author}</span>
-            </>
-          )}
-        </div>
-        {post.tags.length > 0 && (
-          <div className="flex flex-wrap gap-2 mt-3">
-            {post.tags.map((tag) => (
-              <span
-                key={tag}
-                className="text-xs px-2 py-0.5 rounded-full"
-                style={{
-                  backgroundColor: 'var(--color-code-bg)',
-                  color: 'var(--color-text-muted)',
-                }}
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
-        )}
+        {!post.isPrivate && metadata}
       </header>
 
       {post.isPrivate ? (
-        <PasswordGate slug={post.slug} />
+        <PasswordGate slug={post.slug} metadata={metadata} />
       ) : (
         <PostContent pageId={post.id} />
       )}

--- a/src/components/PasswordGate.tsx
+++ b/src/components/PasswordGate.tsx
@@ -3,7 +3,7 @@
 import { useState, type ReactNode } from 'react';
 import DOMPurify from 'dompurify';
 
-export default function PasswordGate({ slug, metadata }: { slug: string; metadata?: ReactNode }) {
+export default function PasswordGate({ slug, children }: { slug: string; children?: ReactNode }) {
   const [password, setPassword] = useState('');
   const [html, setHtml] = useState<string | null>(null);
   const [error, setError] = useState(false);
@@ -38,7 +38,7 @@ export default function PasswordGate({ slug, metadata }: { slug: string; metadat
   if (html) {
     return (
       <>
-        {metadata}
+        {children}
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </>
     );

--- a/src/components/PasswordGate.tsx
+++ b/src/components/PasswordGate.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import DOMPurify from 'dompurify';
 
-export default function PasswordGate({ slug }: { slug: string }) {
+export default function PasswordGate({ slug, metadata }: { slug: string; metadata?: ReactNode }) {
   const [password, setPassword] = useState('');
   const [html, setHtml] = useState<string | null>(null);
   const [error, setError] = useState(false);
@@ -36,7 +36,12 @@ export default function PasswordGate({ slug }: { slug: string }) {
   }
 
   if (html) {
-    return <div dangerouslySetInnerHTML={{ __html: html }} />;
+    return (
+      <>
+        {metadata}
+        <div dangerouslySetInnerHTML={{ __html: html }} />
+      </>
+    );
   }
 
   return (

--- a/src/components/PasswordGate.tsx
+++ b/src/components/PasswordGate.tsx
@@ -38,7 +38,7 @@ export default function PasswordGate({ slug, children }: { slug: string; childre
   if (html) {
     return (
       <>
-        {children}
+        <header className="mb-8">{children}</header>
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </>
     );


### PR DESCRIPTION
For private/password-protected blog posts, the date, author, and tags
are now hidden behind the password gate. Metadata is revealed only
after successful authentication, alongside the post content.

https://claude.ai/code/session_01WxLh3Vi3KQd8drmvrGJcNX